### PR TITLE
BD-909:Relicense RDKSplashScreen to Metrological Apache

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-This component contains software that is Copyright (c) 2020 RDK Management.
+This component contains software that is Copyright (c) 2020 Metrological.
 The component is licensed to you under the Apache License, Version 2.0 (the "License").
 You may not use the component except in compliance with the License.
 
@@ -26,7 +26,7 @@ Copyright (c) 2017 Valentin Richard
 Licensed under the MIT license
 
 Lightning framework is:
-Copyright (c) 2020 RDK Management
+Copyright (c) 2020 Metrological
 Licensed under the Apache License, Version 2.0
 
 Material-Icons is:

--- a/dist/web/js/src.es5/appBundle.js
+++ b/dist/web/js/src.es5/appBundle.js
@@ -34,7 +34,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -268,7 +268,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -468,7 +468,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -525,7 +525,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -686,7 +686,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -808,7 +808,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -1069,7 +1069,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -1209,7 +1209,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -1641,7 +1641,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -2018,7 +2018,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -2159,7 +2159,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -2443,7 +2443,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -2513,7 +2513,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.
@@ -2762,7 +2762,7 @@ var appBundle = function () {
    * If not stated otherwise in this file or this component's LICENSE file the
    * following copyright and licenses apply:
    *
-   * Copyright 2020 RDK Management
+   * Copyright 2020 Metrological
    *
    * Licensed under the Apache License, Version 2.0 (the License);
    * you may not use this file except in compliance with the License.

--- a/dist/web/js/src/appBundle.js
+++ b/dist/web/js/src/appBundle.js
@@ -5,7 +5,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -256,7 +256,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -345,7 +345,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -366,7 +366,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -521,7 +521,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -916,7 +916,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1159,7 +1159,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1237,7 +1237,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1435,7 +1435,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1471,7 +1471,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.
@@ -1586,7 +1586,7 @@ var appBundle = (function () {
 	 * If not stated otherwise in this file or this component's LICENSE file the
 	 * following copyright and licenses apply:
 	 *
-	 * Copyright 2020 RDK Management
+	 * Copyright 2020 Metrological
 	 *
 	 * Licensed under the Apache License, Version 2.0 (the License);
 	 * you may not use this file except in compliance with the License.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
  If not stated otherwise in this file or this component's LICENSE file the
  following copyright and licenses apply:
 
- Copyright 2020 RDK Management
+ Copyright 2020 Metrological
 
  Licensed under the Apache License, Version 2.0 (the License);
  you may not use this file except in compliance with the License.

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/animations/Icons.js
+++ b/src/animations/Icons.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/animations/RDKLogo.js
+++ b/src/animations/RDKLogo.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/LoginButton.js
+++ b/src/components/LoginButton.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/Wifi.js
+++ b/src/components/Wifi.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/WifiItem.js
+++ b/src/components/WifiItem.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/WifiList.js
+++ b/src/components/WifiList.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/WifiLogin.js
+++ b/src/components/WifiLogin.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/keyboard/Keyboard.js
+++ b/src/components/keyboard/Keyboard.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/keyboard/KeyboardButton.js
+++ b/src/components/keyboard/KeyboardButton.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/components/keyboard/KeyboardTemplate.js
+++ b/src/components/keyboard/KeyboardTemplate.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/core/ThunderJS.js
+++ b/src/core/ThunderJS.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/core/WPE.js
+++ b/src/core/WPE.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/core/Wifi.js
+++ b/src/core/Wifi.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reason for change:Relicense RDKSplashScreen to Metrological Apache
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
BD-908:Relicense RDKSplashScreen to Metrological Apache
Risks: None